### PR TITLE
Fixes + Improvements

### DIFF
--- a/contract/assembly/index.ts
+++ b/contract/assembly/index.ts
@@ -7,513 +7,464 @@
  */
 
 import {
-  context,
-  ContractPromiseBatch,
-  logging,
-  PersistentVector,
-  u128,
+    context,
+    ContractPromiseBatch,
+    logging,
+    PersistentVector,
+    u128,
 } from "near-sdk-as";
 import {
-  Admin,
-  adminsUmap,
-  CustomerFeedback,
-  customersUmap,
-  Order,
-  OrderId,
-  OrderStatus,
-  ordersUmap,
-  PaymentType,
-  User,
-  UserRole,
+    Admin,
+    adminsUmap,
+    CustomerFeedback,
+    customersUmap,
+    Order,
+    OrderId,
+    OrderStatus,
+    ordersUmap,
+    PaymentType,
+    User,
+    UserRole,
 } from "./model";
-import { AccountId, assert_self, MIN_ACCOUNT_BALANCE, toYocto } from "./utils";
+import {AccountId, assert_self, MIN_ACCOUNT_BALANCE, toYocto} from "./utils";
 
+/**
+ * Get details about the project
+ * @return Details about the project
+ */
 export function about_project(): string {
-  return "This is a sample project";
+    return "This is a sample project";
 }
 
+
+/**
+ * Get details about the registered customers. Only admin can call this method
+ * @return Array of customers
+ */
 export function call_customers(): User[] {
-  const account_id = context.sender;
-  assert(adminsUmap.contains(account_id), "Only admins can get customers.");
+    const account_id = context.sender;
+    assert(adminsUmap.contains(account_id), "Only admins can get customers.");
 
-  const keys = customersUmap.keys();
-
-  const customerList: User[] = [];
-
-  if (keys.length > 0) {
-    for (let i = 0; i < keys.length; ++i) {
-      if (customersUmap.contains(keys[i])) {
-        customerList[i] = customersUmap.getSome(keys[i]);
-      }
-    }
-  }
-
-  return customerList;
+    return customersUmap.values();
 }
 
+
+/**
+ * Get customer details for the given customer ID. Only admins can view details about the other customers.
+ * However, normal users can view their own details
+ * @return Customer details object for the given ID.
+ */
 export function call_customer_by_account_id(account_id: AccountId): User {
-  assert(account_id.length > 5, "AccountId is required.");
+    assert(account_id.length > 5, "AccountId is required.");
 
-  // assert(
-  //   account_id.endsWith(".testnet"),
-  //   "AccountId must be a testnet account"
-  // );
+    const isAdmin = adminsUmap.contains(context.sender);
+    const isSelf = account_id == context.sender;
 
-  const isAdmin = adminsUmap.contains(context.sender);
+    assert(
+        isAdmin || isSelf,
+        "You are not authorized to view details of this user."
+    );
 
-  const isSelf = account_id == context.sender;
+    assert(customersUmap.contains(account_id), "Customer not found.");
 
-  assert(
-    isAdmin || isSelf,
-    "You are not authorized to view details of this user."
-  );
-
-  assert(customersUmap.contains(account_id), "Customer not found.");
-
-  return customersUmap.getSome(account_id);
+    return customersUmap.getSome(account_id);
 }
 
+
+/**
+ * Get details about the registered orders in the contract. Only admin can call this method
+ * @return Array of orders
+ */
 export function call_orders(): Order[] {
-  const account_id = context.sender;
-  assert(adminsUmap.contains(account_id), "Only admins can get orders.");
+    const account_id = context.sender;
+    assert(adminsUmap.contains(account_id), "Only admins can get orders.");
 
-  const keys = ordersUmap.keys();
-
-  const orderList: Order[] = [];
-
-  if (keys.length > 0) {
-    for (let i = 0; i < keys.length; ++i) {
-      if (ordersUmap.contains(keys[i])) {
-        orderList[i] = ordersUmap.getSome(keys[i]);
-      }
-    }
-  }
-
-  return orderList;
+    return ordersUmap.values();
 }
 
+
+/**
+ * Get order details for the given order ID. Only admins can view details about the other customer orders.
+ * However, normal users can view their own orders.
+ * @return Order details object for the given ID.
+ */
 export function view_order_by_id(order_id: OrderId): Order {
-  assert(order_id.length > 5, "OrderId is required.");
+    assert(order_id.length > 5, "OrderId is required.");
 
-  assert(ordersUmap.contains(order_id), "Order not found.");
+    assert(ordersUmap.contains(order_id), "Order not found.");
 
-  return ordersUmap.getSome(order_id);
-}
+    const order = ordersUmap.getSome(order_id);
 
-export function call_orders_by_customer_account_id(
-  customer_account_id: AccountId
-): Order[] {
-  assert(customer_account_id.length > 5, "AccountId is required.");
+    const isSelf = order.customerId == context.sender;
+    const isAdmin = adminsUmap.contains(context.sender);
 
-  // assert(
-  //   customer_account_id.endsWith(".testnet"),
-  //   "AccountId must be a testnet account"
-  // );
-
-  const account_id = context.sender;
-
-  if (account_id != customer_account_id) {
     assert(
-      adminsUmap.contains(account_id),
-      "Only admins can get orders of other customers."
+        isAdmin || isSelf,
+        "You are not authorized to view details of this order."
     );
-  }
 
-  assert(customersUmap.contains(customer_account_id), "Customer not found.");
-
-  const customer = customersUmap.getSome(customer_account_id);
-
-  const orderIdsLength = customer.orderIds ? customer.orderIds.length : 0;
-
-  const orderList: Order[] = [];
-
-  if (orderIdsLength > 0) {
-    for (let i = 0; i < orderIdsLength; ++i) {
-      if (ordersUmap.contains(customer.orderIds[i])) {
-        orderList[i] = ordersUmap.getSome(customer.orderIds[i]);
-      }
-    }
-  }
-
-  return orderList;
+    return order;
 }
 
+
+/**
+ * Get orders details for the given customer. Only admins can view details about the other customer orders.
+ * However, normal users can view their own orders.
+ * @return Array of orders placed by the given customer.
+ */
+export function call_orders_by_customer_account_id(customer_account_id: AccountId): Order[] {
+    assert(customer_account_id.length > 5, "AccountId is required.");
+
+    const account_id = context.sender;
+
+    const isSelf = customer_account_id == account_id;
+    const isAdmin = adminsUmap.contains(account_id);
+
+    assert(
+        isAdmin || isSelf,
+        "You are not authorized to view details of the given customer orders."
+    );
+
+    assert(customersUmap.contains(customer_account_id), "Customer not found.");
+
+    const customer = customersUmap.getSome(customer_account_id);
+
+    const orderIdsLength = customer.orderIds ? customer.orderIds.length : 0;
+
+    const orderList: Order[] = [];
+
+    if (orderIdsLength > 0) {
+        for (let i = 0; i < orderIdsLength; ++i) {
+            if (ordersUmap.contains(customer.orderIds[i])) {
+                orderList[i] = ordersUmap.getSome(customer.orderIds[i]);
+            }
+        }
+    }
+
+    return orderList;
+}
+
+
+/**
+ * Create a new customer.
+ * @param name Name of the customer.
+ * @param full_address Address of the customer.
+ * @param landmark Landmark details of the customer.
+ * @param google_plus_code_address Google map address of the customer
+ * @param phone Mobile number of the customer
+ * @param email Email of the customer
+ */
 export function call_create_customer(
-  name: string,
-  full_address: string,
-  landmark: string,
-  google_plus_code_address: string,
-  phone: string,
-  email: string
+    name: string,
+    full_address: string,
+    landmark: string,
+    google_plus_code_address: string,
+    phone: string,
+    email: string
 ): void {
-  const account_id = context.sender;
+    const account_id = context.sender;
 
-  assert(account_id.length > 5, "AccountId is required.");
+    assert(account_id.length > 5, "AccountId is required.");
 
-  assert(
-    MIN_ACCOUNT_BALANCE >= u128.from(25),
-    "Minimum account balance required is 25N."
-  );
+    assert(name.length > 2, "Customer Name is required.");
 
-  // assert(
-  //   account_id.endsWith(".testnet"),
-  //   "AccountId must be a testnet account"
-  // );
+    assert(full_address.length > 5, "Customer address is required.");
 
-  assert(name.length > 2, "Customer Name is required.");
+    assert(phone.length > 7, "Customer phone is required.");
 
-  assert(full_address.length > 5, "Customer address is required.");
+    assert(!customersUmap.contains(account_id), "Customer already exists.");
 
-  assert(!customersUmap.contains(account_id), "Customer already exists.");
+    const customer = new User(
+        account_id,
+        name,
+        full_address,
+        landmark,
+        google_plus_code_address,
+        phone,
+        email,
+        UserRole.customer,
+    );
 
-  const customerOrderIds = new PersistentVector<OrderId>("co:" + account_id);
+    customersUmap.set(account_id, customer);
 
-  const customer = new User(
-    account_id,
-    name,
-    full_address,
-    landmark,
-    google_plus_code_address,
-    phone,
-    email,
-    UserRole.customer,
-    customerOrderIds,
-    context.blockTimestamp,
-    context.blockTimestamp
-  );
-
-  assert(customer != null, "Customer is null.");
-
-  customersUmap.set(account_id, customer);
-
-  logging.log(`Customer with account_id: ${account_id} created.`);
+    logging.log(`Customer with account_id: ${account_id} created.`);
 }
 
+
+/**
+ * Update a customer. Only customer can update their own details.
+ * @param name Name of the customer.
+ * @param full_address Address of the customer.
+ * @param landmark Landmark details of the customer.
+ * @param google_plus_code_address Google map address of the customer
+ * @param phone Mobile number of the customer
+ * @param email Email of the customer
+ */
 export function call_update_customer(
-  name: string,
-  full_address: string,
-  landmark: string,
-  google_plus_code_address: string,
-  phone: string,
-  email: string
+    name: string,
+    full_address: string,
+    landmark: string,
+    google_plus_code_address: string,
+    phone: string,
+    email: string
 ): void {
-  const account_id = context.sender;
+    const account_id = context.sender;
 
-  assert(account_id.length > 5, "AccountId is required.");
+    assert(account_id.length > 5, "AccountId is required.");
 
-  assert(
-    MIN_ACCOUNT_BALANCE >= u128.from(25),
-    "Minimum account balance required is 25N."
-  );
+    assert(name.length > 2, "Customer Name is required.");
 
-  // assert(
-  //   account_id.endsWith(".testnet"),
-  //   "AccountId must be a testnet account"
-  // );
+    assert(full_address.length > 5, "Customer address is required.");
 
-  assert(name.length > 2, "Customer Name is required.");
+    assert(phone.length > 7, "Customer phone is required.");
 
-  assert(full_address.length > 5, "Customer address is required.");
+    assert(customersUmap.contains(account_id), "Customer not found.");
 
-  assert(customersUmap.contains(account_id), "Customer not found.");
+    const customer = customersUmap.getSome(account_id);
 
-  const customer = customersUmap.getSome(account_id);
+    assert(customer.id == account_id, "Only customer can update their details.");
 
-  assert(customer != null, "Customer is null.");
+    customer.updateCustomter(name, full_address, landmark, google_plus_code_address, phone, email);
 
-  assert(customer.id == account_id, "Only customer can update their details.");
+    customersUmap.set(account_id, customer);
 
-  customer.name = name;
-  customer.fullAddress = full_address;
-  customer.landmark = landmark;
-  customer.googlePlusCodeAddress = google_plus_code_address;
-  customer.phone = phone;
-  customer.email = email;
-  customer.updated = context.blockTimestamp;
-
-  customersUmap.set(account_id, customer);
-
-  logging.log(`Customer with account_id: ${account_id} updated.`);
+    logging.log(`Customer with account_id: ${account_id} updated.`);
 }
 
+
+/**
+ * Create an order. Only normal customers can create orders.
+ * @param id ID of the order.
+ * @param description Description of the order.
+ * @param weight_in_grams Weight of the order in grams.
+ * @param price_in_yocto_near Price of the order
+ */
 export function call_create_order(
-  id: OrderId,
-  description: string,
-  weight_in_grams: string,
-  price_in_yocto_near: u128
+    id: OrderId,
+    description: string,
+    weight_in_grams: string,
+    price_in_yocto_near: u128
 ): void {
-  const account_id = context.sender;
-  const account_balance = context.accountBalance;
-  const attachedDeposit = context.attachedDeposit;
+    const account_id = context.sender;
+    const attachedDeposit = context.attachedDeposit;
 
-  assert(!adminsUmap.contains(account_id), "Admins cannot create orders.");
-
-  logging.log(
-    `account_id: ${account_id}, account_balance: ${account_balance}, attachedDeposit: ${attachedDeposit}, priceInYoctoNear: ${price_in_yocto_near}.`
-  );
-
-  assert(price_in_yocto_near >= u128.from(3), "Minimum order price is 3 Near.");
-  assert(attachedDeposit >= price_in_yocto_near, "Insufficient deposit.");
-
-  const weightInGrams = I32.parseInt(weight_in_grams);
-
-  const isWeightValid = weightInGrams >= 1000 && weightInGrams <= 10_000;
-  assert(isWeightValid, "Weight must be between 1000 and 10,000 grams.");
-
-  const priceInYoctoNearFor3000Grams = toYocto(3);
-  const priceInYoctoNearFor7000Grams = toYocto(7);
-  const priceInYoctoNearFor10_000Grams = toYocto(10);
-
-  if (weightInGrams >= 1000 && weightInGrams <= 3000) {
-    assert(
-      priceInYoctoNearFor3000Grams <= attachedDeposit,
-      "Order price for upto 3kg weight is 3 Near."
-    );
-  } else if (weightInGrams <= 7000) {
-    assert(
-      priceInYoctoNearFor7000Grams <= attachedDeposit,
-      "Order price for upto 7kg weight is 7 Near."
-    );
-  } else if (weightInGrams <= 10_000) {
-    assert(
-      priceInYoctoNearFor10_000Grams <= attachedDeposit,
-      "Order price for upto 10kg weight is 10 Near."
-    );
-  }
-
-  assert(account_id.length > 5, "CustomerId is required.");
-
-  assert(
-    account_balance >= MIN_ACCOUNT_BALANCE,
-    `Minimum account balance required is ${MIN_ACCOUNT_BALANCE}N.`
-  );
-
-  // assert(
-  //   account_id.endsWith(".testnet"),
-  //   "CustomerId must be a testnet account"
-  // );
-
-  assert(customersUmap.contains(account_id), "Customer not found.");
-
-  assert(id.length > 5, "OrderId is required.");
-
-  assert(!ordersUmap.contains(id), "OrderId already exists.");
-
-  const customer = customersUmap.getSome(account_id);
-
-  assert(customer != null, "Customer is null.");
-
-  const order = new Order(
-    id,
-    account_id,
-    description,
-    weightInGrams,
-    PaymentType.prepaid,
-    attachedDeposit,
-    OrderStatus.confirmed,
-    CustomerFeedback.none,
-    "",
-    context.blockTimestamp,
-    0
-  );
-
-  assert(order != null, "Order is null.");
-
-  ordersUmap.set(id, order);
-
-  customer.orderIds.push(id.toString());
-
-  customersUmap.set(account_id, customer);
-
-  const beneficiary = ContractPromiseBatch.create(context.contractName);
-  beneficiary.transfer(attachedDeposit);
-
-  logging.log(
-    `Order with order_id: ${id} created for customer with account_id: ${account_id}.`
-  );
-
-  logging.log(
-    `Transferred ${attachedDeposit} yoctoNear to contract account: ${context.contractName}`
-  );
-}
-
-export function call_update_order_status(
-  order_id: OrderId,
-  order_status: OrderStatus
-): void {
-  const admin_account_id = context.sender;
-
-  assert(admin_account_id.length > 5, "AccountId is required.");
-
-  // assert(
-  //   admin_account_id.endsWith(".testnet"),
-  //   "AccountId must be a testnet account"
-  // );
-
-  assert(adminsUmap.contains(admin_account_id), "Admin not found.");
-
-  const admin = adminsUmap.getSome(admin_account_id);
-
-  assert(admin != null, "Admin is null.");
-
-  assert(admin.role == UserRole.admin, "Only admins can update order status.");
-
-  const isOrderStatusValid =
-    order_status == OrderStatus.confirmed ||
-    order_status == OrderStatus.inProgress ||
-    order_status == OrderStatus.delivered ||
-    order_status == OrderStatus.cancelled;
-
-  assert(isOrderStatusValid, "Invalid order status.");
-
-  assert(order_id.length > 5, "OrderId is required.");
-
-  assert(ordersUmap.contains(order_id), "Order not found.");
-
-  const order = ordersUmap.getSome(order_id);
-
-  assert(order != null, "Order is null.");
-
-  if (order_status == OrderStatus.confirmed) {
-    assert(order.status != OrderStatus.confirmed, "Order already confirmed.");
-    assert(order.status != OrderStatus.inProgress, "Order already inProgress.");
-    assert(order.status != OrderStatus.delivered, "Order already delivered.");
-    assert(order.status != OrderStatus.cancelled, "Order already cancelled.");
-  } else if (order_status == OrderStatus.inProgress) {
-    assert(
-      order.status == OrderStatus.confirmed,
-      "Order must have confirmed status."
-    );
-    order.status = order_status;
-  } else if (order_status == OrderStatus.delivered) {
-    assert(
-      order.status == OrderStatus.inProgress,
-      "Order must have inProgress status."
-    );
-
-    order.status = order_status;
-
-    order.deliveryDateTime = context.blockTimestamp;
-
-    const beneficiary = ContractPromiseBatch.create(admin_account_id);
-    beneficiary.transfer(order.priceInYoctoNear);
+    assert(!adminsUmap.contains(account_id), "Admins cannot create orders.");
 
     logging.log(
-      `Transferred ${order.priceInYoctoNear} yoctoNear to account_id: ${admin_account_id}`
+        `account_id: ${account_id}, attachedDeposit: ${attachedDeposit}, priceInYoctoNear: ${price_in_yocto_near}.`
     );
-  } else if (order_status == OrderStatus.cancelled) {
-    assert(order.status != OrderStatus.cancelled, "Order already cancelled.");
-    assert(order.status != OrderStatus.delivered, "Order already delivered.");
 
-    order.status = order_status;
+    assert(price_in_yocto_near >= u128.from(3), "Minimum order price is 3 Near.");
+    assert(attachedDeposit >= price_in_yocto_near, "Insufficient deposit.");
 
-    const beneficiary = ContractPromiseBatch.create(order.customerId);
-    beneficiary.transfer(order.priceInYoctoNear);
+    const weightInGrams = parseInt(weight_in_grams);
 
-    logging.log(
-      `Refunded ${order.priceInYoctoNear} yoctoNear to account_id: ${order.customerId}`
-    );
-  }
+    const isWeightValid = weightInGrams >= 1000 && weightInGrams <= 10_000;
+    assert(isWeightValid, "Weight must be between 1000 and 10,000 grams.");
 
-  ordersUmap.set(order_id, order);
+    const priceInYoctoNearFor7000Grams = toYocto(7);
+    const priceInYoctoNearFor10_000Grams = toYocto(10);
 
-  logging.log(
-    `Order with order_id: ${order_id} has updated status: ${order_status}.`
-  );
-}
-
-export function call_customer_feedback(
-  order_id: OrderId,
-  customer_feedback: string,
-  customer_feedback_comment: string
-): void {
-  const customerId = context.sender;
-  const account_balance = context.accountBalance;
-
-  assert(customerId.length > 5, "CustomerId is required.");
-
-  assert(
-    account_balance >= MIN_ACCOUNT_BALANCE,
-    `Minimum account balance required is ${MIN_ACCOUNT_BALANCE}N.`
-  );
-
-  // assert(
-  //   customerId.endsWith(".testnet"),
-  //   "CustomerId must be a testnet account"
-  // );
-
-  assert(customersUmap.contains(customerId), "Customer not found.");
-  const customer = customersUmap.getSome(customerId);
-  assert(customer != null, "Customer is null.");
-
-  assert(order_id.length > 5, "OrderId is required.");
-  assert(ordersUmap.contains(order_id), "Order not found.");
-  const order = ordersUmap.getSome(order_id);
-  assert(order != null, "Order is null.");
-  assert(
-    order.status == 3,
-    "Order must be masked as Delivered to submit feedback."
-  );
-  assert(order.customerId == customerId, "Customer not authorized.");
-
-  order.customerFeedback = I32.parseInt(customer_feedback, 10);
-  order.customerFeedbackComment = customer_feedback_comment;
-
-  ordersUmap.set(order_id, order);
-
-  logging.log(
-    `Customer with account_id: ${customerId} has provided feedback for order with order_id: ${order_id}.`
-  );
-}
-
-export function view_admins(): string[] {
-  const keys = adminsUmap.keys();
-
-  const adminList: string[] = [];
-
-  if (keys.length > 0) {
-    for (let i = 0; i < keys.length; ++i) {
-      if (adminsUmap.contains(keys[i])) {
-        const adm = adminsUmap.getSome(keys[i]);
-        adminList[i] = adm.id;
-      }
+    if (weightInGrams >= 3000 && weightInGrams <= 7000) {
+        assert(
+            priceInYoctoNearFor7000Grams <= attachedDeposit,
+            "Order price for upto 7kg weight is 7 Near."
+        );
+    } else if (weightInGrams <= 10_000) {
+        assert(
+            priceInYoctoNearFor10_000Grams <= attachedDeposit,
+            "Order price for upto 10kg weight is 10 Near."
+        );
     }
-  }
 
-  return adminList;
+    assert(account_id.length > 5, "CustomerId is required.");
+
+    assert(customersUmap.contains(account_id), "Customer not found.");
+
+    assert(id.length > 5, "OrderId is required.");
+
+    assert(!ordersUmap.contains(id), "OrderId already exists.");
+
+    const customer = customersUmap.getSome(account_id);
+
+    const order = new Order(
+        id,
+        account_id,
+        description,
+        weightInGrams,
+        PaymentType.prepaid,
+        attachedDeposit,
+        OrderStatus.confirmed,
+        CustomerFeedback.none,
+        "",
+        0
+    );
+
+    ordersUmap.set(id, order);
+
+    customer.orderIds.push(id.toString());
+
+    customersUmap.set(account_id, customer);
+
+    const beneficiary = ContractPromiseBatch.create(context.contractName);
+    beneficiary.transfer(attachedDeposit);
+
+    logging.log(
+        `Order with order_id: ${id} created for customer with account_id: ${account_id}.`
+    );
+
+    logging.log(
+        `Transferred ${attachedDeposit} yoctoNear to contract account: ${context.contractName}`
+    );
 }
 
+
+/**
+ * Update the order status after processing each step. Only admins can call this function.
+ * @param order_id ID of the order.
+ * @param order_status Latest status of the order.
+ */
+export function call_update_order_status(
+    order_id: OrderId,
+    order_status: OrderStatus
+): void {
+    const admin_account_id = context.sender;
+
+    assert(admin_account_id.length > 5, "AccountId is required.");
+
+    assert(adminsUmap.contains(admin_account_id), "Only admins can update order status.");
+
+    const isOrderStatusValid =
+        order_status == OrderStatus.confirmed ||
+        order_status == OrderStatus.inProgress ||
+        order_status == OrderStatus.delivered ||
+        order_status == OrderStatus.cancelled;
+
+    assert(isOrderStatusValid, "Invalid order status.");
+
+    assert(order_id.length > 5, "OrderId is required.");
+
+    assert(ordersUmap.contains(order_id), "Order not found.");
+
+    const order = ordersUmap.getSome(order_id);
+
+    if (order_status == order.status) {
+
+        assert(order.status != OrderStatus.confirmed, "Order already confirmed.");
+        assert(order.status != OrderStatus.inProgress, "Order already inProgress.");
+        assert(order.status != OrderStatus.delivered, "Order already delivered.");
+        assert(order.status != OrderStatus.cancelled, "Order already cancelled.");
+
+    } else if (order_status == OrderStatus.inProgress) {
+
+        assert(order.status == OrderStatus.confirmed, "Order must have confirmed status.");
+        order.updateStatus(order_status);
+
+    } else if (order_status == OrderStatus.delivered) {
+
+        assert(order.status == OrderStatus.inProgress, "Order must have inProgress status.");
+        order.deliverOrder();
+
+        const beneficiary = ContractPromiseBatch.create(admin_account_id);
+        beneficiary.transfer(order.priceInYoctoNear);
+
+        logging.log(`Transferred ${order.priceInYoctoNear} yoctoNear to account_id: ${admin_account_id}`);
+
+    } else if (order_status == OrderStatus.cancelled) {
+        assert(order.status != OrderStatus.cancelled, "Order already cancelled.");
+        assert(order.status != OrderStatus.delivered, "Order already delivered.");
+
+        order.updateStatus(order_status);
+
+        const beneficiary = ContractPromiseBatch.create(order.customerId);
+        beneficiary.transfer(order.priceInYoctoNear);
+
+        logging.log(`Refunded ${order.priceInYoctoNear} yoctoNear to account_id: ${order.customerId}`);
+    }
+
+    ordersUmap.set(order_id, order);
+
+    logging.log(`Order with order_id: ${order_id} has updated status: ${order_status}.`);
+}
+
+
+/**
+ * Get customer feedback for the delivered order.
+ * @param order_id ID of the order.
+ * @param customer_feedback Feedback rating.
+ * @param customer_feedback_comment Feedback comment
+ */
+export function call_customer_feedback(
+    order_id: OrderId,
+    customer_feedback: string,
+    customer_feedback_comment: string
+): void {
+    const customerId = context.sender;
+
+    assert(customerId.length > 5, "CustomerId is required.");
+
+    assert(customersUmap.contains(customerId), "Customer not found.");
+
+    assert(order_id.length > 5, "OrderId is required.");
+
+    assert(ordersUmap.contains(order_id), "Order not found.");
+
+    const order = ordersUmap.getSome(order_id);
+
+    assert(order.status == 3, "Order must be masked as Delivered to submit feedback.");
+    assert(order.customerId == customerId, "Only customer have access.");
+
+    order.addFeedback(customer_feedback, customer_feedback_comment);
+
+    ordersUmap.set(order_id, order);
+
+    logging.log(`Customer with account_id: ${customerId} has provided feedback for order with order_id: ${order_id}.`);
+}
+
+
+/**
+ * Get admin IDs of the contract.
+ * @return Array of admin account IDs.
+ */
+export function view_admins(): string[] {
+    const keys = adminsUmap.keys();
+
+    const adminList: string[] = [];
+
+    if (keys.length > 0) {
+        for (let i = 0; i < keys.length; ++i) {
+            if (adminsUmap.contains(keys[i])) {
+                const adm = adminsUmap.getSome(keys[i]);
+                adminList[i] = adm.id;
+            }
+        }
+    }
+
+    return adminList;
+}
+
+
+/**
+ * Add admins to the contract. Only accessible to contract deployed account.
+ * @param admin_account_id Account ID of the admin.
+ */
 export function init(admin_account_id: string): void {
-  const account_id = context.sender;
-  const predecessor = context.predecessor;
-  const account_balance = context.accountBalance;
-  const attachedDeposit = context.attachedDeposit;
+    const account_id = context.sender;
+    const predecessor = context.predecessor;
+    const account_balance = context.accountBalance;
+    const attachedDeposit = context.attachedDeposit;
 
-  logging.log(
-    `account_id: ${account_id}, predecessor: ${predecessor}, account_balance: ${account_balance}, attachedDeposit: ${attachedDeposit}.`
-  );
+    assert_self();
 
-  assert_self();
+    logging.log(`account_id: ${account_id}, predecessor: ${predecessor}, account_balance: ${account_balance}, attachedDeposit: ${attachedDeposit}.`);
 
-  assert(
-    MIN_ACCOUNT_BALANCE >= u128.from(25),
-    "Minimum account balance required is 25N."
-  );
+    assert(admin_account_id.length > 5, "AccountId is required.");
 
-  // assert(
-  //   admin_account_id.endsWith(".testnet"),
-  //   "AccountId must be a testnet account"
-  // );
+    assert(!adminsUmap.contains(admin_account_id), "Admin already exists.");
 
-  assert(!adminsUmap.contains(admin_account_id), "Admin already exists.");
+    const admin = new Admin(admin_account_id);
 
-  const admin = new Admin(
-    admin_account_id,
-    context.blockTimestamp,
-    context.blockTimestamp
-  );
+    adminsUmap.set(admin_account_id, admin);
 
-  adminsUmap.set(admin_account_id, admin);
-
-  logging.log(`Admin with account_id: ${admin_account_id} created.`);
+    logging.log(`Admin with account_id: ${admin_account_id} created.`);
 }

--- a/contract/assembly/model.ts
+++ b/contract/assembly/model.ts
@@ -1,5 +1,6 @@
 import { PersistentUnorderedMap, PersistentVector } from "near-sdk-core";
 import { AccountId, Amount, Timestamp } from "./utils";
+import {context} from "near-sdk-as";
 
 /**
  * all available order statuses
@@ -44,10 +45,10 @@ export class Admin {
   created: Timestamp;
   updated: Timestamp;
 
-  constructor(id: AccountId, created: Timestamp, updated: Timestamp) {
+  constructor(id: AccountId) {
     this.id = id;
-    this.created = created;
-    this.updated = updated;
+    this.created = context.blockTimestamp;
+    this.updated = context.blockTimestamp;
   }
 }
 
@@ -74,9 +75,6 @@ export class User {
     phone: string,
     email: string,
     role: UserRole,
-    orderIds: PersistentVector<OrderId>,
-    created: Timestamp,
-    updated: Timestamp
   ) {
     this.id = id;
     this.name = name;
@@ -86,9 +84,26 @@ export class User {
     this.phone = phone;
     this.email = email;
     this.role = role;
-    this.orderIds = orderIds;
-    this.created = created;
-    this.updated = updated;
+    this.orderIds = new PersistentVector<OrderId>("co:" + id);
+    this.created = context.blockTimestamp;
+    this.updated = context.blockTimestamp;
+  }
+
+  public updateCustomter(
+      name: string,
+      fullAddress: string,
+      landmark: string,
+      googlePlusCodeAddress: string,
+      phone: string,
+      email: string,
+  ) {
+    this.name = name;
+    this.fullAddress = fullAddress;
+    this.landmark = landmark;
+    this.googlePlusCodeAddress = googlePlusCodeAddress;
+    this.phone = phone;
+    this.email = email;
+    this.updated = context.blockTimestamp;
   }
 }
 
@@ -97,7 +112,7 @@ export class Order {
   id: OrderId;
   customerId: AccountId;
   description: string;
-  weightInGrams: i32;
+  weightInGrams: u32;
   priceInYoctoNear: Amount;
   paymentType: PaymentType = PaymentType.prepaid;
   status: OrderStatus = OrderStatus.confirmed;
@@ -110,13 +125,12 @@ export class Order {
     id: OrderId,
     customerId: AccountId,
     description: string,
-    weightInGrams: i32,
+    weightInGrams: u32,
     paymentType: PaymentType,
     priceInYoctoNear: Amount,
     status: OrderStatus,
     customerFeedback: CustomerFeedback,
     customerFeedbackComment: string,
-    pickupDateTime: Timestamp,
     deliveryDateTime: Timestamp
   ) {
     this.id = id;
@@ -128,8 +142,22 @@ export class Order {
     this.status = status;
     this.customerFeedback = customerFeedback;
     this.customerFeedbackComment = customerFeedbackComment;
-    this.pickupDateTime = pickupDateTime;
+    this.pickupDateTime = context.blockTimestamp;
     this.deliveryDateTime = deliveryDateTime;
+  }
+
+  public deliverOrder(){
+    this.status = OrderStatus.delivered;
+    this.deliveryDateTime = context.blockTimestamp;
+  }
+
+  public updateStatus(status: OrderStatus) {
+    this.status = status;
+  }
+
+  public addFeedback(customer_feedback: string, customer_feedback_comment: string) {
+    this.customerFeedback = parseInt(customer_feedback, 10);
+    this.customerFeedbackComment = customer_feedback_comment;
   }
 }
 


### PR DESCRIPTION
## Fixes 

1. Inside `call_customers` and `call_orders` functions, I see that you are first getting the `keys` by calling `.keys()` function and then iterating over `keys` to get one item at a time and pushing it to another `array`. After that, you are returning that array. However, that is unnecessary and costs more gas. You can just easily call .`values()` method for any `PersistentUnorderedMap` to get the stored values as an array. I fixed that.
2. Also I see that you are trying to get the account balance of the accounts who are interacting with the smart contract by calling `context.accountBalance`. But that's not gonna work because it returns the balance of the smart contract, not the user account. As of now, there isn't a way to get the user balance using `context`. However, you can pass the balance using frontend as a `parameter` if you really need that. You can find the available property details of the `context` here. (https://near-docs.io/develop/contracts/environment/)
3. Furthermore, I've removed that assert for `MIN_ACCOUNT_BALANCE`. Because as I mentioned above, it won't be useful since it doesn't give the balance of the user's account.
4. I've updated the `constructors` of all the models. So that you won't have to pass creating `timestamp` to the constructor while creating an object. It'll automatically set the current timestamp using `context.blockTimestamp` when you are creating an object.
5. I've added `updateCustomter` method to the `Customer` model. So when you are updating a customer, you won't have to set each item one by one. Instead, you can pass all the parameters to the `updateCustomter` method. It'll set the new values in that method.
6. Added `deliverOrder`, `updateStatus`, and `addFeedback` methods for the Order model. So you won't have to set these things one by one, every time when you need to update those. Instead, you can just pass the new values.
7.  Changed the type of `weightInGrams` to `u32` instead of `i32`. Because i32 is used to store both negative and positive values. Since weight is always a positive number, its type should be u32. More info can be found here. (https://learning-rust.github.io/docs/a8.primitive_data_types.html#i8-i16-i32-i64-i128)
8. I see that you are always checking for `null` after getting data from the state even after you make sure that it is present in the state. So it is unnecessary. I removed that for all the places. Below is just an example.  https://github.com/ramandeepbhagat/washkart/blob/74794022b39851231c67ffa6f28850f42aef76a3/contract/assembly/index.ts#L371-L375
9. I see that you're trying to check if the calling account is a `testnet` account or not. If you need that, I suggest you to create another function like `self_assert` and implement the functionality there. After that, you can call it at the top of every function.
10. Added comments to the functions with `@param` and `@return` variables. Also removed some unnecessary coding parts and optimized the contract.